### PR TITLE
Switch to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ ifdef MSWIN
     SHELL_SH = 1
 
     ifdef GNUWIN
-        PYCMD = python
+        PYCMD = python3
         PLCMD = perl
     endif
 
@@ -461,7 +461,7 @@ dist-oxt: myspell
 
 MANIFEST:
 	mkdir -p $(D_BUILD)
-	python -c \
+	python3 -c \
 	'from distutils.core import setup; \
 	 setup(name = "-", version = "-", url = "-", \
 	       author = "-", author_email = "-")' \

--- a/tools/aff2utf8.awk
+++ b/tools/aff2utf8.awk
@@ -47,7 +47,7 @@ BEGIN {
 
     if (!converter) {
         if (PY_ICONV) {
-            converter = "python -u " PY_ICONV " -f ISO-8859-13 -t UTF-8"
+            converter = "python3 -u " PY_ICONV " -f ISO-8859-13 -t UTF-8"
         } else {
             print "No suitable converter found and PY_ICONV is not set."\
                 > "/dev/stderr"

--- a/tools/iconv.py
+++ b/tools/iconv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Laimonas Vėbra

--- a/tools/ispell2myspell.py
+++ b/tools/ispell2myspell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016, Laimonas Vėbra

--- a/tools/sort.py
+++ b/tools/sort.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: iso-8859-13 -*-
 #
 # Autorius: Laimonas Vëbra, 2010

--- a/tools/sutrauka.py
+++ b/tools/sutrauka.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: iso-8859-13 -*-
 #
 # Autorius: Albertas Agejevas, 2003

--- a/tools/utils/spell.py
+++ b/tools/utils/spell.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: iso-8859-13 -*-
 '''
 $Id: spell.py,v 1.4 2003/11/24 23:51:16 alga Exp $
 
 Paleidimas:
 
-  python spell.py [-m] [infile]
+  python3 spell.py [-m] [infile]
 
      -m     -- nurodo, kad þodþius reikia dëti á lietuviu.zodziai ir
                lietuviu.veiksmazodziai, o ne lietuviu.privatus

--- a/tools/utils/validator/donelaitis.py
+++ b/tools/utils/validator/donelaitis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Priemonës þodþiø ieðkoti VDU KLC tekstyne per webiná interfeisà.
 

--- a/tools/utils/validator/ispell.py
+++ b/tools/utils/validator/ispell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Priemonës kreiptis á ispell þodynà.
 

--- a/tools/utils/validator/runtests.sh
+++ b/tools/utils/validator/runtests.sh
@@ -3,4 +3,4 @@
 export PYTHONPATH=`dirname $0`
 export DICTIONARY=${PYTHONPATH}/../lietuviu
 
-python tests/test_donelaitis.py
+python3 tests/test_donelaitis.py


### PR DESCRIPTION
Switch to python3, however this then fails to build:

```
$ ./debian/rules clean build
dh clean
   dh_auto_clean
	make -j1 clean
make[1]: Entering directory '/tmp/ispell-lt'
rm -f liet-utf8.*
rm -f lietuviu.dict lietuviu.stat lietuviu.hash
find . -depth -path './build' -type d -exec rm -rf '{}' ';'
find . -depth -path './dist' -type d -exec rm -rf '{}' ';'
find . -depth -path './tmp' -type d -exec rm -rf '{}' ';'
make[1]: Leaving directory '/tmp/ispell-lt'
   debian/rules override_dh_clean
make[1]: Entering directory '/tmp/ispell-lt'
dh_clean
	rm -f debian/debhelper-build-stamp
	rm -rf debian/.debhelper/
	rm -f debian/aspell-lt.debhelper.log debian/ilithuanian.debhelper.log
	rm -f -- debian/ilithuanian.substvars debian/aspell-lt.substvars debian/files
	rm -fr -- debian/ilithuanian/ debian/tmp/ debian/aspell-lt/
	find .  \( \( \
		\( -path .\*/.git -o -path .\*/.svn -o -path .\*/.bzr -o -path .\*/.hg -o -path .\*/CVS -o -path .\*/.pc -o -path .\*/_darcs \) -prune -o -type f -a \
	        \( -name '#*#' -o -name '.*~' -o -name '*~' -o -name DEADJOE \
		 -o -name '*.orig' -o -name '*.rej' -o -name '*.bak' \
		 -o -name '.*.orig' -o -name .*.rej -o -name '.SUMS' \
		 -o -name TAGS -o \( -path '*/.deps/*' -a -name '*.P' \) \
		\) -exec rm -f {} + \) -o \
		\( -type d -a -name autom4te.cache -prune -exec rm -rf {} + \) \)
rm -f lietuviu.mwl.gz
rm -rf debian/tmpdir
rm -f lt.cwl.gz
make[1]: Leaving directory '/tmp/ispell-lt'
dh build
   dh_update_autotools_config
   dh_auto_configure
   debian/rules override_dh_auto_build
make[1]: Entering directory '/tmp/ispell-lt'
mkdir -p debian/tmpdir/usr/lib/locale
localedef -i "lt_LT" -f "ISO-8859-13" "debian/tmpdir/usr/lib/locale/lt_LT.ISO-8859-13"
# Using the locale
(export LOCPATH=debian/tmpdir/usr/lib/locale; export LC_ALL=lt_LT.ISO-8859-13; /usr/bin/make myspell)
make[2]: Entering directory '/tmp/ispell-lt'
cat lietuviu.zodziai lietuviu.jargon lietuviu.vardai lietuviu.veiksmazodziai lietuviu.ivpk lietuviu.ivairus |  tools/sutrauka.py > lietuviu.dict
tools/sutrauka.py:36: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if os.name is "nt":
Could not set locale 'lt_LT.ISO8859-13', default: '('lt_LT', 'ISO8859-13')'. Won't be able to sort dictionary words correctly.

--- tools/sutrauka.py --------------------------------------
Reading ............................
Processing ............ done.
Words before: 134702, words after: 85792.
(words constringed: 48910, bytes saved: 648248)
------------------------------------------------------------
mkdir -p build/myspell
wc -l < lietuviu.dict | tr -d ' ' > build/myspell/lt_LT.dic
cat lietuviu.dict >> build/myspell/lt_LT.dic
mkdir -p build/myspell
tools/ispell2myspell.py -c etc/myspell/myspell.aff -s lietuviu.aff > build/myspell/lt_LT.aff
Output (myspell aff) encoding not specified; assuming the same as input 'iso8859-13'.
make[2]: Leaving directory '/tmp/ispell-lt'
gzip -cn9 lietuviu.dict > lietuviu.mwl.gz
cp lietuviu.dict lt.wl
prezip lt.wl
gzip -n9 lt.cwl
/usr/bin/make aspell
make[2]: Entering directory '/tmp/ispell-lt'
mkdir -p build/aspell
cp -f etc/aspell/lt.dat build/aspell
cp -f lietuviu.dict build/aspell/lt.wl
cp -f build/myspell/lt_LT.aff build/aspell/lt_affix.dat
sed -e 's/@VERSION@/1.3.1-2020.03.31/' \
     etc/aspell/info.in > build/aspell/info
cd build/aspell; LC_ALL=C  ./proc.pl
cd build/aspell; ./configure
Finding Dictionary file location ... /usr/lib/aspell
Finding Data file location ... /usr/lib/aspell
/usr/bin/make -C build/aspell lt.rws
make[3]: Entering directory '/tmp/ispell-lt/build/aspell'
cat lt.wl | LC_COLLATE=C /usr/bin/sort -u | /usr/bin/prezip-bin -z > lt.cwl
/usr/bin/prezip-bin -d < lt.cwl  | /usr/bin/aspell  --lang=lt create master ./lt.rws
Error: .//lt_affix.dat:741: The condition "[[^i]]as" is invalid.
make[3]: *** [Makefile:74: lt.rws] Error 1
make[3]: Leaving directory '/tmp/ispell-lt/build/aspell'
make[2]: *** [Makefile:256: aspell] Error 2
make[2]: Leaving directory '/tmp/ispell-lt'
make[1]: *** [debian/rules:17: override_dh_auto_build] Error 2
make[1]: Leaving directory '/tmp/ispell-lt'
make: *** [debian/rules:6: build] Error 2

```

See also https://github.com/ispell-lt/ispell-lt/issues/22